### PR TITLE
Support to export the PDF data for iOS && macOS. iOS need iOS 11+ for keeping vector format.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: objective-c
-osx_image: xcode9.4
+osx_image: xcode10.2
+
+addons:
+  homebrew:
+    packages:
+    - carthage
+    update: true
 
 env:
   global:
@@ -15,10 +21,8 @@ notifications:
 before_install:
   - env
   - locale
-  - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
-  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
-  - brew update
-  - brew upgrade carthage
+  - gem install cocoapods --no-document --quiet
+  - gem install xcpretty --no-document --quiet
   - pod --version
   - pod setup --silent > /dev/null
   - pod repo update --silent
@@ -30,7 +34,7 @@ script:
   - set -o pipefail
 
   - echo Check if the library described by the podspec can be built
-  #- pod lib lint --allow-warnings
+  - pod lib lint --allow-warnings
 
   - echo Build as dynamic frameworks
   - carthage update --platform ios,tvos,macos --configuration DEBUG

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "SDWebImage/SDWebImage" "5.0.0"
+github "SDWebImage/SDWebImage" "5.0.2"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - SDWebImage (5.0.0):
-    - SDWebImage/Core (= 5.0.0)
-  - SDWebImage/Core (5.0.0)
+  - SDWebImage (5.0.2):
+    - SDWebImage/Core (= 5.0.2)
+  - SDWebImage/Core (5.0.2)
   - SDWebImagePDFCoder (0.2.0):
     - SDWebImage (~> 5.0)
 
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  SDWebImage: 5de80a0302de9e377e62f47d2fa1304efff0e55f
+  SDWebImage: 6764b5fa0f73c203728052955dbefa2bf1f33282
   SDWebImagePDFCoder: e980f143f97ff0bf8366a4b74d0acb50f0c9d8b6
 
 PODFILE CHECKSUM: 13cc95bf609e99946808ed65a198e32a645f3acd

--- a/Example/SDWebImagePDFCoder-Example-macOS/ViewController.m
+++ b/Example/SDWebImagePDFCoder-Example-macOS/ViewController.m
@@ -36,6 +36,8 @@
     [imageView1 sd_setImageWithURL:pdfURL placeholderImage:nil options:SDWebImageRetryFailed completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
             NSLog(@"PDF load success");
+            NSData *pdfData = [image sd_imageDataAsFormat:SDImageFormatPDF];
+            NSAssert(pdfData.length > 0, @"PDF Data export failed");
         }
     }];
     [imageView2 sd_setImageWithURL:pdfURL2 placeholderImage:nil options:SDWebImageRetryFailed context:@{SDWebImageContextPDFImageSize : @(imageView2.bounds.size)} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {

--- a/Example/SDWebImagePDFCoder/SDViewController.m
+++ b/Example/SDWebImagePDFCoder/SDViewController.m
@@ -42,6 +42,8 @@
     [imageView1 sd_setImageWithURL:pdfURL placeholderImage:nil options:SDWebImageRetryFailed completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
             NSLog(@"PDF load success");
+            NSData *pdfData = [image sd_imageDataAsFormat:SDImageFormatPDF];
+            NSAssert(pdfData.length > 0, @"PDF Data export failed");
         }
     }];
     [imageView2 sd_setImageWithURL:pdfURL2 placeholderImage:nil options:SDWebImageRetryFailed context:@{SDWebImageContextPDFImageSize : @(imageView2.bounds.size)} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {

--- a/SDWebImagePDFCoder.xcodeproj/project.pbxproj
+++ b/SDWebImagePDFCoder.xcodeproj/project.pbxproj
@@ -28,10 +28,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		32CA9E9C2185BC3D00322AF3 /* SDWebImagePDFCoder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImagePDFCoder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		32CA9E9C2185BC3D00322AF3 /* SDWebImagePDFCoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImagePDFCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		32CA9EA72185BC7400322AF3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Module/Info.plist; sourceTree = "<group>"; };
-		32CA9EAE2185BCEA00322AF3 /* SDWebImagePDFCoder_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImagePDFCoder_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		32CA9EBB2185BD0700322AF3 /* SDWebImagePDFCoder_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImagePDFCoder_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		32CA9EAE2185BCEA00322AF3 /* SDWebImagePDFCoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImagePDFCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		32CA9EBB2185BD0700322AF3 /* SDWebImagePDFCoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImagePDFCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		32CA9EC32185BDBB00322AF3 /* SDWebImagePDFCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDWebImagePDFCoder.h; path = Module/SDWebImagePDFCoder.h; sourceTree = "<group>"; };
 		32CA9EC82185BDC300322AF3 /* SDWebImagePDFCoderDefine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImagePDFCoderDefine.h; sourceTree = "<group>"; };
 		32CA9ECA2185BDC300322AF3 /* SDImagePDFCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDImagePDFCoder.h; sourceTree = "<group>"; };
@@ -82,9 +82,9 @@
 		32CA9E9D2185BC3D00322AF3 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				32CA9E9C2185BC3D00322AF3 /* SDWebImagePDFCoder_iOS.framework */,
-				32CA9EAE2185BCEA00322AF3 /* SDWebImagePDFCoder_tvOS.framework */,
-				32CA9EBB2185BD0700322AF3 /* SDWebImagePDFCoder_macOS.framework */,
+				32CA9E9C2185BC3D00322AF3 /* SDWebImagePDFCoder.framework */,
+				32CA9EAE2185BCEA00322AF3 /* SDWebImagePDFCoder.framework */,
+				32CA9EBB2185BD0700322AF3 /* SDWebImagePDFCoder.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -171,7 +171,7 @@
 			);
 			name = "SDWebImagePDFCoder iOS";
 			productName = SDWebImagePDFCoder;
-			productReference = 32CA9E9C2185BC3D00322AF3 /* SDWebImagePDFCoder_iOS.framework */;
+			productReference = 32CA9E9C2185BC3D00322AF3 /* SDWebImagePDFCoder.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		32CA9EAD2185BCEA00322AF3 /* SDWebImagePDFCoder tvOS */ = {
@@ -189,7 +189,7 @@
 			);
 			name = "SDWebImagePDFCoder tvOS";
 			productName = "SDWebImagePDFCoder-tvOS";
-			productReference = 32CA9EAE2185BCEA00322AF3 /* SDWebImagePDFCoder_tvOS.framework */;
+			productReference = 32CA9EAE2185BCEA00322AF3 /* SDWebImagePDFCoder.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		32CA9EBA2185BD0700322AF3 /* SDWebImagePDFCoder macOS */ = {
@@ -207,7 +207,7 @@
 			);
 			name = "SDWebImagePDFCoder macOS";
 			productName = "SDWebImagePDFCoder-macOS";
-			productReference = 32CA9EBB2185BD0700322AF3 /* SDWebImagePDFCoder_macOS.framework */;
+			productReference = 32CA9EBB2185BD0700322AF3 /* SDWebImagePDFCoder.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -444,8 +444,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.SDWebImagePDFCoder-iOS";
-				PRODUCT_MODULE_NAME = SDWebImagePDFCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImagePDFCoder;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -473,8 +472,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.SDWebImagePDFCoder-iOS";
-				PRODUCT_MODULE_NAME = SDWebImagePDFCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImagePDFCoder;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -501,8 +499,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.SDWebImagePDFCoder-tvOS";
-				PRODUCT_MODULE_NAME = SDWebImagePDFCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImagePDFCoder;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
@@ -531,8 +528,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.SDWebImagePDFCoder-tvOS";
-				PRODUCT_MODULE_NAME = SDWebImagePDFCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImagePDFCoder;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
@@ -564,8 +560,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.SDWebImagePDFCoder-macOS";
-				PRODUCT_MODULE_NAME = SDWebImagePDFCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImagePDFCoder;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -595,8 +590,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.SDWebImagePDFCoder-macOS";
-				PRODUCT_MODULE_NAME = SDWebImagePDFCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImagePDFCoder;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};


### PR DESCRIPTION
### PR descrition

This PR support to export the vector PDF data, from `UIImage`/`NSImage` instance. Which keep the original vector data (may loss PDF metadata on iOS only, macOS does not impact).

See the result:

```objective-c
NSData *pdfData = [image sd_imageDataAsFormat:SDImageFormatPDF];
[pdfData writeToFile:@"/tmp/1.pdf" atomically:YES];
```

![image](https://user-images.githubusercontent.com/6919743/57578750-bde7ae00-74c4-11e9-86c4-d857a569f551.png)