### PR TITLE
Fix the issue that PDF bitmap representation cropBox does not get applied (vector still exist)

### DIFF
--- a/SDWebImagePDFCoder/Classes/SDImagePDFCoder.m
+++ b/SDWebImagePDFCoder/Classes/SDImagePDFCoder.m
@@ -135,10 +135,18 @@ static inline NSString *SDBase64DecodedString(NSString *base64String) {
     UIGraphicsBeginPDFPageWithInfo(rect, nil);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
+    
     // Core Graphics Coordinate System convert
     CGContextScaleCTM(context, 1, -1);
     CGContextTranslateCTM(context, 0, -CGRectGetHeight(rect));
+    
+    // Clip the drawing to the CropBox
+    CGRect cropBox = CGPDFPageGetBoxRect(page, kCGPDFCropBox);
+    CGContextAddRect(context, cropBox);
+    CGContextClip(context);
+    
     CGContextDrawPDFPage(context, page);
+    
     UIGraphicsEndPDFContext();
     
     return [data copy];
@@ -234,6 +242,11 @@ static inline NSString *SDBase64DecodedString(NSString *base64String) {
     
     CGContextConcatCTM(context, scaleTransform);
     CGContextConcatCTM(context, transform);
+    
+    // Clip the drawing to the CropBox
+    CGRect cropBox = CGPDFPageGetBoxRect(page, kCGPDFCropBox);
+    CGContextAddRect(context, cropBox);
+    CGContextClip(context);
     
     CGContextDrawPDFPage(context, page);
     


### PR DESCRIPTION
See test case:

https://github.com/unidoc/unipdf/files/3964182/cropbox.pdf

Note that UIImage vector image rendering does not considerate the cropBox, this can not been solved by us...